### PR TITLE
Add virtual destructors, fix variable types for loops

### DIFF
--- a/src/Jinja2CppLight.cpp
+++ b/src/Jinja2CppLight.cpp
@@ -62,7 +62,7 @@ Template &Template::setValue( std::string name, std::string value ) {
 }
 std::string Template::render() {
 //    cout << "tempalte::render root=" << root << endl;
-    int finalPos = eatSection(0, root );
+    size_t finalPos = eatSection(0, root );
     cout << finalPos << " vs " << sourceCode.length() << endl;
     if( finalPos != sourceCode.length() ) {
         root->print("");
@@ -86,7 +86,7 @@ int Template::eatSection( int pos, ControlSection *controlSection ) {
 //    string updatedString = "";
     while( true ) {
 //        cout << "pos: " << pos << endl;
-        int controlChangeBegin = sourceCode.find( "{%", pos );
+        size_t controlChangeBegin = sourceCode.find( "{%", pos );
 //        cout << "controlChangeBegin: " << controlChangeBegin << endl;
         if( controlChangeBegin == string::npos ) {
             //updatedString += doSubstitutions( sourceCode.substr( pos ), valueByName );
@@ -98,7 +98,7 @@ int Template::eatSection( int pos, ControlSection *controlSection ) {
             controlSection->sections.push_back( code );
             return sourceCode.length();
         } else {
-            int controlChangeEnd = sourceCode.find( "%}", controlChangeBegin );
+            size_t controlChangeEnd = sourceCode.find( "%}", controlChangeBegin );
             if( controlChangeEnd == string::npos ) {
                 throw render_error( "control section unterminated: " + sourceCode.substr( controlChangeBegin, 40 ) );
             }
@@ -173,7 +173,7 @@ int Template::eatSection( int pos, ControlSection *controlSection ) {
                 forSection->varName = varname;
                 pos = eatSection( controlChangeEnd + 2, forSection );
                 controlSection->sections.push_back(forSection);
-                int controlEndEndPos = sourceCode.find("%}", pos );
+                size_t controlEndEndPos = sourceCode.find("%}", pos );
                 if( controlEndEndPos == string::npos ) {
                     throw render_error("No control end section found at: " + sourceCode.substr(pos ) );
                 }
@@ -219,7 +219,7 @@ STATIC std::string Template::doSubstitutions( std::string sourceCode, std::map< 
     if( startI == 1 ) {
         templatedString = splitSource[0];
     }
-    for( int i = startI; i < splitSource.size(); i++ ) {
+    for( size_t i = startI; i < splitSource.size(); i++ ) {
         vector<string> thisSplit = split( splitSource[i], "}}" );
         string name = trim( thisSplit[0] );
 //        cout << "name: " << name << endl;

--- a/src/Jinja2CppLight.h
+++ b/src/Jinja2CppLight.h
@@ -32,6 +32,7 @@ public:
 
 class Value {
 public:
+    virtual ~Value() {}
     virtual std::string render() = 0;
 };
 class IntValue : public Value {
@@ -136,7 +137,7 @@ public:
         }
         for( int i = loopStart; i < loopEnd; i++ ) {
             valueByName[varName] = new IntValue( i );
-            for( int j = 0; j < sections.size(); j++ ) {
+            for( size_t j = 0; j < sections.size(); j++ ) {
                 result += sections[j]->render( valueByName );
             }
             delete valueByName[varName];
@@ -180,6 +181,7 @@ public:
 
 class Root : public ControlSection {
 public:
+    virtual ~Root() {}
 //    std::vector< ControlSection * >sections;
     virtual std::string render( std::map< std::string, Value *> &valueByName ) {
         std::string resultString = "";


### PR DESCRIPTION
Discovered warning messages while using the library when developing something.

Clang moans that 'delete' gets called on the abstract classes 'Value' and 'Root' but those
should have virtual destructor, what is not the case at the moment.

Furthermore it laments that the signed integers do not have the same sign as the ones returned by length(), string::npos and size().