### PR TITLE
Bug fix: Passing template rendering when template variable is at the …

### DIFF
--- a/src/Jinja2CppLight.cpp
+++ b/src/Jinja2CppLight.cpp
@@ -261,6 +261,11 @@ STATIC std::string Template::doSubstitutions( std::string sourceCode, std::map< 
         templatedString = splitSource[0];
     }
     for( size_t i = startI; i < splitSource.size(); i++ ) {
+        if (0 == i && splitSource.size() > 1 && splitSource[i].empty()) // Ignoring initial empty section if there are other sections.
+        {
+            continue;
+        }
+
         vector<string> thisSplit = split( splitSource[i], "}}" );
         string name = trim( thisSplit[0] );
 //        cout << "name: " << name << endl;


### PR DESCRIPTION
…begin of template source.

There was failure for following example case: "{{MY_VARIABLE_AT_THE_BEGIN}}of template".