### PR TITLE
Install header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,4 +53,5 @@ target_include_directories(jinja2cpplight_unittests PRIVATE thirdparty/gtest)
     ARCHIVE DESTINATION lib
     RUNTIME DESTINATION bin
 )
+install(FILES src/Jinja2CppLight.h src/stringhelper.h DESTINATION include/Jinja2CppLight)
 


### PR DESCRIPTION
The project does install only the shared library, but it's unusable without headers.

P.S. I use it with CMake's `ExternalProject_Add()`